### PR TITLE
Fix encoding when searching with special chars

### DIFF
--- a/lib/streak.rb
+++ b/lib/streak.rb
@@ -105,7 +105,7 @@ module Streak
   private
 
   def self.uri_encode(params)
-    params.map { |k,v| "#{k}=#{URI.escape(v)}" }.join("&")
+    params.map { |k,v| "#{k}=#{URI.encode_www_form_component(v)}" }.join("&")
   end
 
 end

--- a/lib/streak/search.rb
+++ b/lib/streak/search.rb
@@ -1,7 +1,8 @@
 module Streak
   class Search < StreakObject
     def self.query(s_query)
-      res = Streak.request(:get, "/v1/search", {query: s_query})
+      query = s_query.is_a?(String) ? {query: s_query} : s_query
+      res = Streak.request(:get, "/v1/search", query)
       convert_to_streak_object(res, Search)
     end
   end

--- a/lib/streak/search.rb
+++ b/lib/streak/search.rb
@@ -1,7 +1,10 @@
 module Streak
   class Search < StreakObject
-    def self.query(s_query)
-      query = s_query.is_a?(String) ? {query: s_query} : s_query
+    def self.query(query)
+      self.query_hash({query: query})
+    end
+
+    def self.query_hash(query)
       res = Streak.request(:get, "/v1/search", query)
       convert_to_streak_object(res, Search)
     end


### PR DESCRIPTION
I was trying to search for companies with names having characters like "(", "&", "%" and the search was failing due to the encode function. This PR fixed the issues I was facing.